### PR TITLE
[Refactor] + Feature update #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Ctrl + C
 ### How to Contribute?
 * Make sure that your changes do not conflict with the core files (changing file directories will require a change in all called paths)
 * Follow the original code structure
-* Refactoring contributions are welcome, explicitly mention "[Refractor]" in your pull request
+* Refactoring contributions are welcome, explicitly mention "[Refactor]" in your pull request
 * Give a few days to review PRs, code reviews are welcome 
 
 ### Steps to sync fork with master (Open Source Contributors):

--- a/src/main_search.py
+++ b/src/main_search.py
@@ -13,6 +13,7 @@ from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.action_chains import ActionChains
 from pyvirtualdisplay import Display
+from getkey import getkey
 
 quitTitle = False
 
@@ -115,8 +116,9 @@ class Search():
             self.look_up_playlist()
 
             while True:
-                val = input(Fore.LIGHTRED_EX +
+                print(Fore.LIGHTRED_EX +
                     "New song: s\nPause: o\nNext song: p\nPrev song: i\nQuit: q\n>")
+                val = getkey()
                 self.action(val)
 
         except KeyboardInterrupt:


### PR DESCRIPTION
Feature update for issue #6 
- YouTube has [shortcuts](https://support.google.com/youtube/answer/7631406?hl=en) to control webplayer.
- Used `ActionChains` library to send keystrokes to chrome instance.

Changed `quit()` -> `action()`
- Implemented play/pause, next, prev and quit.
- Known [selenium issue](https://github.com/SeleniumHQ/selenium/issues/6837) marked as closed, but while testing the issue #6 functionality, method `reset_actions()` was not behaving as expected. Solution: Set ActionChains variable to `None` after performing an operation.

[Refactor]
- webdriver object was only available in `Search.search()` context, which killed the chrome instance when searching for a new song. This also would not let user perform actions (play/pause etc.)
- Removed redundant title display and spawned a thread that achieves the same task. Thread is killed with a global flag variable when application is quit.
- Refactored playlist output.